### PR TITLE
Update index.js

### DIFF
--- a/src/twitch-webhook-create/index.js
+++ b/src/twitch-webhook-create/index.js
@@ -26,7 +26,8 @@ exports.handler = async event => {
     const options = {
       url: 'https://api.twitch.tv/helix/webhooks/subscriptions',
       headers: {
-        Authorization: appToken
+        Authorization: appToken,
+        'Client-Id': process.env.client_id
       },
       json: true
     };


### PR DESCRIPTION
It needs this to work, throws `{"error":"Unauthorized","status":401,"message":"Client ID and OAuth token do not match"}` otherwise.